### PR TITLE
Update kraken to 1.2.5

### DIFF
--- a/kraken.rb
+++ b/kraken.rb
@@ -2,8 +2,8 @@ class Kraken < Formula
   desc "Command line interface for kraken"
   homepage "https://github.com/samsung-cnct/kraken"
 
-  url "https://github.com/samsung-cnct/kraken/releases/download/1.2.3/kraken_1.2.3_darwin_amd64.tar.gz"
-  sha256 "81595b9973f3087889e220d48105da3dec717fd30a54466ddd0be798ed85355e"
+  url "https://github.com/samsung-cnct/kraken/releases/download/1.2.5/kraken_1.2.5_darwin_amd64.tar.gz"
+  sha256 "a648a10d8c430b883d188f0b666e887b161276fe2bde33da842efcd14f010a3a"
 
   depends_on "docker"
 


### PR DESCRIPTION
napcae@Trungs-MacBook-Pro:/p/tmp
➤ shasum -a 256 kraken_1.2.5_darwin_amd64.tar.gz
a648a10d8c430b883d188f0b666e887b161276fe2bde33da842efcd14f010a3a  kraken_1.2.5_darwin_amd64.tar.gz